### PR TITLE
Add a configurable SNOMED CT edition to generated suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ At a high level, a config file contains:
 - **`title`**: Test suite title (also used to derive Ruby module names and paths)
 - **`extra_json_paths`**: Additional JSON configs to merge
 - **`tx_server_url`**: Terminology server URL used by generated tests
+- **`snomed_edition`**: SNOMED CT edition the validator resolves version-less `http://snomed.info/sct` codes against, emitted as `cliContext.snomedCT`. An edition SCTID, or an alias such as `au`, `us`, `uk`, `intl`. Defaults to `au`. Must match an edition the configured `tx_server_url` actually carries: the validator otherwise fails every SNOMED lookup with "A definition for CodeSystem 'http://snomed.info/sct' version 'null' could not be found" and then reports valid codes as absent from their value sets.
 - **`links`**: Links shown in the Inferno UI (e.g. “Report Issue”, “IG Documentation”)
 - **`outer_groups`**: Extra groups to include before/after generated groups:
     - `import_type`

--- a/config.example.json
+++ b/config.example.json
@@ -11,6 +11,7 @@
     "title": "AU Core",
     "extra_json_paths": ["search-params.json"],
     "tx_server_url": "https://tx.dev.hl7.org.au/fhir",
+    "snomed_edition": "au",
     "outer_groups": [
       {
         "import_type": "relative",

--- a/config.example2.json
+++ b/config.example2.json
@@ -12,6 +12,7 @@
     "title": "Smart Health Checks",
     "extra_json_paths": ["search-params.json", "example-resources.json"],
     "tx_server_url": "https://tx.dev.hl7.org.au/fhir",
+    "snomed_edition": "au",
     "outer_groups": [],
     "links": [
       {

--- a/lib/inferno_suite_generator/core/config/getters.rb
+++ b/lib/inferno_suite_generator/core/config/getters.rb
@@ -18,6 +18,22 @@ module InfernoSuiteGenerator
           get("suite.tx_server_url")
         end
 
+        # SNOMED CT edition the validator resolves version-less http://snomed.info/sct
+        # codes against, as a cliContext.snomedCT value (an edition SCTID, or one of the
+        # aliases in SnomedUtilities.getCodeFromAlias such as "au", "us", "uk", "intl").
+        #
+        # The validator defaults this to the International edition
+        # (900000000000207008) and turns it into the expansion parameter
+        # "system-version=http://snomed.info/sct|http://snomed.info/sct/<edition>". A
+        # terminology server that does not carry that edition then fails every SNOMED
+        # lookup with "A definition for CodeSystem 'http://snomed.info/sct' version
+        # 'null' could not be found", after which the validator reports valid codes as
+        # absent from their value sets. Set this to match what suite.tx_server_url
+        # actually carries.
+        def snomed_edition
+          get("suite.snomed_edition", "au")
+        end
+
         def resources_configs
           get("configs.resources", EMPTY_HASH)
         end

--- a/lib/inferno_suite_generator/core/config/getters.rb
+++ b/lib/inferno_suite_generator/core/config/getters.rb
@@ -18,18 +18,6 @@ module InfernoSuiteGenerator
           get("suite.tx_server_url")
         end
 
-        # SNOMED CT edition the validator resolves version-less http://snomed.info/sct
-        # codes against, as a cliContext.snomedCT value (an edition SCTID, or one of the
-        # aliases in SnomedUtilities.getCodeFromAlias such as "au", "us", "uk", "intl").
-        #
-        # The validator defaults this to the International edition
-        # (900000000000207008) and turns it into the expansion parameter
-        # "system-version=http://snomed.info/sct|http://snomed.info/sct/<edition>". A
-        # terminology server that does not carry that edition then fails every SNOMED
-        # lookup with "A definition for CodeSystem 'http://snomed.info/sct' version
-        # 'null' could not be found", after which the validator reports valid codes as
-        # absent from their value sets. Set this to match what suite.tx_server_url
-        # actually carries.
         def snomed_edition
           get("suite.snomed_edition", "au")
         end

--- a/lib/inferno_suite_generator/generators/suite_generator.rb
+++ b/lib/inferno_suite_generator/generators/suite_generator.rb
@@ -40,6 +40,10 @@ module InfernoSuiteGenerator
         config_keeper.tx_server_url
       end
 
+      def snomed_edition
+        config_keeper.snomed_edition
+      end
+
       def module_name
         "#{ig_metadata.ig_module_name_prefix}#{ig_metadata.reformatted_version.upcase}"
       end

--- a/lib/inferno_suite_generator/templates/suite.rb.erb
+++ b/lib/inferno_suite_generator/templates/suite.rb.erb
@@ -41,6 +41,7 @@ module <%= suite_module_name %>
 
         cli_context do
           txServer ENV.fetch('TX_SERVER_URL', '<%= tx_server_url %>')
+          snomedCT ENV.fetch('SNOMED_EDITION', '<%= snomed_edition %>')
           disableDefaultResourceFetcher false
         end
 

--- a/sig/inferno_suite_generator.rbs
+++ b/sig/inferno_suite_generator.rbs
@@ -65,6 +65,7 @@ module InfernoSuiteGenerator
         include Utils
 
         def tx_server_url: () -> String
+        def snomed_edition: () -> String
         def resources_configs: () -> Hash[String, untyped]
         def ig_link: () -> String
         def ig_name: () -> String


### PR DESCRIPTION
## Problem

`templates/suite.rb.erb` emits `cliContext.txServer` but leaves `cliContext.snomedCT` at the validator's default, the SNOMED **International** edition (`900000000000207008`). `ValidationEngine.setSnomedExtension` turns that into an expansion parameter:

```
system-version = http://snomed.info/sct|http://snomed.info/sct/900000000000207008
```

A terminology server that does not carry that edition then fails every SNOMED lookup with `A definition for CodeSystem 'http://snomed.info/sct' version 'null' could not be found`, and the validator goes on to report valid codes as absent from their value sets. Every suite generated from this template inherits the problem silently, because the symptom presents as content warnings rather than a configuration error.

This is live against `tx.dev.hl7.org.au`, which the config examples already point at and which carries only the Australian edition.

## Change

The generator already parameterises the terminology server, so the edition that server carries belongs beside it. Adds `suite.snomed_edition`, emitted into the same `cli_context` block:

```ruby
cli_context do
  txServer ENV.fetch('TX_SERVER_URL', '<%= tx_server_url %>')
  snomedCT ENV.fetch('SNOMED_EDITION', '<%= snomed_edition %>')
  disableDefaultResourceFetcher false
end
```

Accepts an edition SCTID or one of the aliases in `SnomedUtilities.getCodeFromAlias` (`au`, `us`, `uk`, `intl`, …). Defaults to `au`, consistent with the existing `tx_server_url` in both config examples; set it explicitly for any other server. Runtime override via `SNOMED_EDITION`, matching the existing `TX_SERVER_URL` treatment.

Config examples and the README config reference are updated.

## Impact measured elsewhere

Same fix applied by hand to the AU PS suite, validating its `aups-basicsummary` example against `tx.dev.hl7.org.au`:

| profile | before | after |
|---|---|---|
| AU PS Bundle | 28 warnings / 19 info | **8 / 9** |
| IPS Bundle | 30 warnings / 28 info | **10 / 21** |

Identical on validator-wrapper 1.0.78 (core 6.9.7) and 1.0.81 (core 6.9.12). A spurious `error` on a contained Medication's AMT code is removed. Note the IPS row: selecting the Australian edition improves International-profile validation too, because the AU edition is a derivative containing the full International release.

## Related

- hl7au/au-ps-inferno#108
- hl7au/au-fhir-core-inferno#299 (AU Core carries its own copy of this template, fixed there in parallel)