### PR TITLE
Fix reference target profile version, and stop reporting non-conformance as a skip

### DIFF
--- a/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
+++ b/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
@@ -16,7 +16,17 @@ module InfernoSuiteGenerator
 
       pass if unresolved_references(resources, rewrite_profile_url, readable_resource_types).empty?
 
-      skip_with_msg "Could not resolve and validate any Must Support references for #{unresolved_references_strings.join(", ")}"
+      # Distinguish the two ways a target can fail. A reference that was read
+      # successfully but whose target does not conform to its profile is a
+      # finding about the data, not an absence of data, and reporting it as a
+      # skip hides it. Only a genuinely unreachable reference is a skip.
+      if nonconformant_reference_targets.any?
+        assert false,
+               "Resolved Must Support references whose targets do not conform to their profile: " \
+               "#{nonconformant_reference_targets.join(", ")}"
+      end
+
+      skip_with_msg "Could not resolve any Must Support references for #{unresolved_references_strings.join(", ")}"
     end
 
     def unresolved_references_strings
@@ -58,6 +68,13 @@ module InfernoSuiteGenerator
 
     def resolved_references
       scratch[:resolved_references] ||= Set.new
+    end
+
+    # References that were read successfully but whose target failed validation
+    # against its declared profile. Kept per test rather than in scratch, since
+    # it describes this test's findings rather than session-wide state.
+    def nonconformant_reference_targets
+      @nonconformant_reference_targets ||= Set.new
     end
 
     def no_resources_skip_message
@@ -170,18 +187,29 @@ module InfernoSuiteGenerator
 
       return false unless resolved_resource&.resourceType == reference_type && resolved_resource&.id == reference_id
 
-      return false unless resource_is_valid_with_target_profile?(resolved_resource, target_profile, rewrite_profile_url)
+      unless resource_is_valid_with_target_profile?(resolved_resource, target_profile, rewrite_profile_url)
+        # The read succeeded, so the reference is reachable. The target simply
+        # does not conform. Remember that so the caller can report it as a
+        # finding rather than as missing data.
+        nonconformant_reference_targets << "#{reference.reference} (#{target_profile})"
+        return false
+      end
 
       record_resolved_reference(reference, target_profile)
       true
     end
 
     def get_target_profile_with_version(target_profile, rewrite_profile_url)
-      if rewrite_profile_url.key?(target_profile)
-        rewrite_profile_url[target_profile]
-      else
-        "#{target_profile}|#{metadata.profile_version}"
-      end
+      return rewrite_profile_url[target_profile] if rewrite_profile_url.key?(target_profile)
+
+      # Reference targets are frequently profiles from a dependency rather than
+      # from the IG being generated, so the IG's own version does not apply to
+      # them. Asking the validator for au-core-patient|<this IG's version>
+      # requests a profile that was never published, which the validator
+      # rejects outright, and resource_is_valid_with_target_profile? turns that
+      # into a failed assertion. Leave the canonical unversioned and let the
+      # validator resolve whichever version the loaded packages supply.
+      target_profile
     end
 
     def resource_is_valid_with_target_profile?(resource, target_profile, rewrite_profile_url)

--- a/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
+++ b/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
@@ -20,23 +20,60 @@ module InfernoSuiteGenerator
       # successfully but whose target does not conform to its profile is a
       # finding about the data, not an absence of data, and reporting it as a
       # skip hides it. Only a genuinely unreachable reference is a skip.
-      if nonconformant_reference_targets.any?
-        assert false,
-               "Resolved Must Support references whose targets do not conform to their profile: " \
-               "#{nonconformant_reference_targets.join(", ")}"
-      end
+      #
+      # Findings are matched back to the element they were collected for, so a
+      # non-conformant target on an element that did resolve is never reported
+      # as the reason a different element failed to resolve.
+      findings = nonconformant_findings_for_unresolved_references
+
+      assert findings.empty?, nonconformant_reference_message(findings)
 
       skip_with_msg "Could not resolve any Must Support references for #{unresolved_references_strings.join(", ")}"
     end
 
-    def unresolved_references_strings
+    def unresolved_references_strings(references = unresolved_references)
       unresolved_reference_hash =
-        unresolved_references.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |missing, hash|
+        references.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |missing, hash|
           hash[missing[:path]] << missing[:target_profile]
         end
       unresolved_reference_hash.map do |path, profiles|
         "#{path} element: Reference#{"(#{profiles.join("|")})" unless profiles.first.empty?}"
       end
+    end
+
+    # Reported as a failure: the element did not resolve, and at least one of
+    # its targets was read but did not conform.
+    def nonconformant_findings_for_unresolved_references
+      nonconformant_reference_findings.select do |finding|
+        unresolved_references.any? { |pair| finding_matches_reference_pair?(finding, pair) }
+      end
+    end
+
+    # Reported alongside the failure: the element did not resolve and nothing
+    # was read, so there is no conformance finding to attach to it.
+    def unreachable_unresolved_references
+      unresolved_references.reject do |pair|
+        nonconformant_reference_findings.any? { |finding| finding_matches_reference_pair?(finding, pair) }
+      end
+    end
+
+    def nonconformant_reference_message(findings)
+      described = findings.map do |finding|
+        "#{finding[:path]} element: #{finding[:reference]} does not conform to #{finding[:target_profile]}"
+      end
+
+      message = "Must Support references resolved to targets that do not conform to their profile: " \
+                "#{described.join(", ")}"
+
+      unreachable = unresolved_references_strings(unreachable_unresolved_references)
+      return message if unreachable.empty?
+
+      "#{message}. Could not resolve any Must Support references for #{unreachable.join(", ")}"
+    end
+
+    def finding_matches_reference_pair?(finding, pair)
+      finding[:target_profile] == pair[:target_profile] &&
+        (finding[:path].nil? || finding[:path] == pair[:path])
     end
 
     def record_resolved_reference(reference, target_profile)
@@ -72,9 +109,16 @@ module InfernoSuiteGenerator
 
     # References that were read successfully but whose target failed validation
     # against its declared profile. Kept per test rather than in scratch, since
-    # it describes this test's findings rather than session-wide state.
-    def nonconformant_reference_targets
-      @nonconformant_reference_targets ||= Set.new
+    # it describes this test's findings rather than session-wide state. Each
+    # entry records the Must Support element it was collected for so findings
+    # can be matched back to the element that failed to resolve.
+    def nonconformant_reference_findings
+      @nonconformant_reference_findings ||= []
+    end
+
+    def record_nonconformant_reference_target(path, reference, target_profile)
+      finding = { path:, reference: reference.reference, target_profile: }
+      nonconformant_reference_findings << finding unless nonconformant_reference_findings.include?(finding)
     end
 
     def no_resources_skip_message
@@ -100,65 +144,81 @@ module InfernoSuiteGenerator
       end.flatten
     end
 
+    # Memoised in full, including the choice filtering below. The filter's
+    # predicate reads the collection it is mutating, so running it again on an
+    # already filtered collection can remove further entries. Callers read this
+    # more than once per test, so it has to settle on the first call.
     def unresolved_references(resources = [], rewrite_profile_url = {}, readable_resource_types = [])
-      @unresolved_references ||=
-        must_support_references_with_target_profile.select do |reference_path_profile_pair|
-          path = reference_path_profile_pair[:path]
-          target_profile = reference_path_profile_pair[:target_profile]
+      @unresolved_references ||= begin
+        unresolved =
+          must_support_references_with_target_profile.select do |reference_path_profile_pair|
+            path = reference_path_profile_pair[:path]
+            target_profile = reference_path_profile_pair[:target_profile]
 
-          found_one_reference = false
+            found_one_reference = false
 
-          resolve_one_reference = resources.any? do |resource|
-            value_found = resolve_path(resource, path, metadata:)
-            next if value_found.empty?
+            resolve_one_reference = resources.any? do |resource|
+              value_found = resolve_path(resource, path, metadata:)
+              next if value_found.empty?
 
-            resolvable = if readable_resource_types.present?
-                           value_found.select { |ref| readable_resource_types.include?(ref.resource_type) }
-                         else
-                           value_found
-                         end
+              resolvable = if readable_resource_types.present?
+                             value_found.select { |ref| readable_resource_types.include?(ref.resource_type) }
+                           else
+                             value_found
+                           end
 
-            next if resolvable.empty?
+              next if resolvable.empty?
 
-            found_one_reference = true
+              found_one_reference = true
 
-            resolvable.any? do |reference|
-              validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url)
-            end
-          end
-
-          found_one_reference && !resolve_one_reference
-        end
-
-      if metadata.must_supports[:choices].present?
-        @unresolved_references.delete_if do |reference|
-          choice_profiles = metadata.must_supports[:choices].find do |choice|
-            choice[:target_profiles]&.include?(reference[:target_profile])
-          end
-
-          choice_profiles.present? &&
-            choice_profiles[:target_profiles]&.any? do |profile|
-              @unresolved_references.none? do |element|
-                element[:target_profile] == profile
+              resolvable.any? do |reference|
+                validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url, path:)
               end
             end
-        end
-      end
 
-      @unresolved_references
+            found_one_reference && !resolve_one_reference
+          end
+
+        if metadata.must_supports[:choices].present?
+          unresolved.delete_if do |reference|
+            choice_profiles = metadata.must_supports[:choices].find do |choice|
+              choice[:target_profiles]&.include?(reference[:target_profile])
+            end
+
+            choice_profiles.present? &&
+              choice_profiles[:target_profiles]&.any? do |profile|
+                unresolved.none? do |element|
+                  element[:target_profile] == profile
+                end
+              end
+          end
+        end
+
+        unresolved
+      end
     end
 
-    def validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url)
+    def validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url, path: nil)
       return true if is_reference_resolved?(reference, target_profile)
 
       if reference.contained?
         # if reference_id is blank it is referring to itself, so we know it exists
         return true if reference.reference_id.blank?
 
-        return resource.contained.any? do |contained_resource|
-                 contained_resource&.id == reference.reference_id &&
-                 resource_is_valid_with_target_profile?(contained_resource, target_profile, rewrite_profile_url)
-               end
+        contained = Array(resource.contained).select { |candidate| candidate&.id == reference.reference_id }
+
+        # Nothing with that id means the reference is unresolvable. Something
+        # with that id that fails validation is the same finding as a
+        # non-conformant external target, so it is recorded the same way.
+        return false if contained.empty?
+
+        conforms = contained.any? do |contained_resource|
+          resource_is_valid_with_target_profile?(contained_resource, target_profile, rewrite_profile_url)
+        end
+        return true if conforms
+
+        record_nonconformant_reference_target(path, reference, target_profile)
+        return false
       end
 
       reference_type = reference.resource_type
@@ -191,7 +251,7 @@ module InfernoSuiteGenerator
         # The read succeeded, so the reference is reachable. The target simply
         # does not conform. Remember that so the caller can report it as a
         # finding rather than as missing data.
-        nonconformant_reference_targets << "#{reference.reference} (#{target_profile})"
+        record_nonconformant_reference_target(path, reference, target_profile)
         return false
       end
 
@@ -199,7 +259,7 @@ module InfernoSuiteGenerator
       true
     end
 
-    def get_target_profile_with_version(target_profile, rewrite_profile_url)
+    def resolve_target_profile_canonical(target_profile, rewrite_profile_url)
       return rewrite_profile_url[target_profile] if rewrite_profile_url.key?(target_profile)
 
       # Reference targets are frequently profiles from a dependency rather than
@@ -217,7 +277,7 @@ module InfernoSuiteGenerator
 
       validator = find_validator(:default)
 
-      target_profile_with_version = get_target_profile_with_version(target_profile, rewrite_profile_url)
+      target_profile_with_version = resolve_target_profile_canonical(target_profile, rewrite_profile_url)
       begin
         # add_messages_to_runnable is false because we only need to know if the resource is valid;
         # logging every failed reference target as an error would be noisy.


### PR DESCRIPTION
Two defects in the same code path, both found while tracing why two reference resolution tests skipped against a live server while twelve structurally identical ones passed.

## 1. The unmapped-target fallback asks for a profile that does not exist

```ruby
def get_target_profile_with_version(target_profile, rewrite_profile_url)
  if rewrite_profile_url.key?(target_profile)
    rewrite_profile_url[target_profile]
  else
    "#{target_profile}|#{metadata.profile_version}"   # <-- the generated IG's version
  end
end
```

Reference targets are usually profiles from a **dependency**, so the IG's own version does not apply to them. A suite generated for an IG at `0.4.0` asks the validator for:

```
http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient|0.4.0
```

which was never published. Measured against a live HL7 validator:

| Requested profile | Validator response |
| --- | --- |
| `au-core-patient` (unversioned) | 200, validates normally |
| `au-core-patient\|2.0.0` | 200, validates normally |
| `au-core-patient\|0.4.0` | **HTTP 500** |

`resource_is_valid_with_target_profile?` catches that and does `assert false`, so the test errors instead of reporting anything useful.

This is also why `rewrite_profile_url` has to be populated at all: it is a workaround for the fallback rather than a feature most suites need. With the fallback fixed, a suite can leave the map empty unless it genuinely needs to pin a version.

**Change**: unmapped targets are left unversioned; the validator resolves whichever version the loaded packages supply. The method is renamed to `resolve_target_profile_canonical`, since it no longer adds a version. It has no callers outside this file.

**Trade-off worth naming**: an unversioned canonical is ambiguous if a validator session ever loads two versions of the same profile. In practice each suite pins one IG and its dependency graph resolves to a single version, so this does not bite today, and `rewrite_profile_url` remains the escape hatch when it does.

## 2. Non-conformance is reported as a skip

`perform_reference_resolution_test` collapsed two different outcomes into one message and one result:

- the reference could not be read, and
- the reference read fine but its target does not conform to its profile

Both produced `Could not resolve and validate any Must Support references` **and a skip**. The second is a finding about the data, and a skip hides it: the reader sees "no data to test" when the truth is "the referenced resource is non-conformant".

**Change**: non-conformant targets are collected and reported as a failure naming the element, the reference and the profile. Genuinely unreachable references stay a skip.

Findings are attributed to the Must Support element they were collected for. Without that, a non-conformant target on an element that *did* resolve would supply the failure message for a different element that could not be read at all, naming a target that was not the reason the test failed and omitting the one that was. When both outcomes occur together, both are reported in the same message rather than one displacing the other.

Non-conformant *contained* targets are recorded the same way; previously they returned a bare `false` and so still surfaced as a skip.

**Scope, so it is not read as more than it is**: because the test passes as soon as one target resolves and conforms, this reports non-conformance only for elements where *no* target conformed. A non-conformant target sitting alongside a conformant one still passes silently. That preserves the existing pass semantics; widening it would be a separate change.

## What this looked like in practice

Full trace against a live server, all steps verified:

| Observation | Evidence |
| --- | --- |
| `resources.any?` stops at the first reference that resolves **and** validates | source |
| `Patient/pat-sf` fails `au-core-patient` with 29 errors (it carries `http://www.acme.com/identifiers/patient`) | validated directly |
| `Patient/baby-smith-john` validates cleanly, 0 errors | validated directly |
| Observation groups pass: they contain resources referencing the conformant patient | 7 such resources on the server |
| Encounter and MedicationStatement skip: every subject reference is to the non-conformant patient | 0 such resources on the server |

The finding was real, was reported correctly by the patient validation test, and was silently downgraded to a skip here.

The version pin was **not** the cause of those skips: unversioned, `|2.0.0` and `|2.0.0-ballot` all return the same 29 errors, because the validator also validates against the resource's own `meta.profile`. The two defects are independent; they just live in the same method.

## Notes

- `unresolved_references` is now memoised in full, including the choice filtering. That filter's predicate reads the collection it is mutating, so calling the method a second time could remove further entries. It was reachable before and the reporting added here reads the collection more than once, so it had to settle on the first call.
- The failure names the reference and the profile but not the validation errors behind it, because `resource_is_valid_with_target_profile?` passes `add_messages_to_runnable: false` to keep every failed candidate out of the log. Surfacing the underlying errors for the targets that actually get reported would need a second validation pass and is left as a follow-up.
- `ruby -c` passes. `lib/inferno_suite_generator/test_modules/reference_resolution_test.rb` is in the global `AllCops: Exclude` list (`.rubocop.yml:48`), so rubocop does not inspect it.
- Related: #29 fixes the SNOMED edition default in the suite template, same theme of a default that fails quietly.
