### PR TITLE
Register every bundle entry, and stop logging duplicates

### DIFF
--- a/lib/inferno_suite_generator/test_modules/basic_test.rb
+++ b/lib/inferno_suite_generator/test_modules/basic_test.rb
@@ -72,12 +72,14 @@ module InfernoSuiteGenerator
     def register_resource_id_from_bundle(bundle)
       return unless bundle
 
-      bundle.entry&.map do |entry|
+      bundle.entry&.each do |entry|
         resource = entry&.resource
+        next if resource.nil?
+        # `return` here abandoned the whole bundle at the first already-known
+        # id, so every later entry went unregistered. Skip the entry instead.
+        next if existing_demo_resources.include? resource.id
 
         info "Registering #{resource.id} of #{resource.resourceType} for resource IDs registry"
-        return if existing_demo_resources.include? resource.id
-
         existing_demo_resources << resource.id
       end
     end


### PR DESCRIPTION
`register_resource_id_from_bundle` uses `return` inside the block iterating bundle entries:

```ruby
bundle.entry&.map do |entry|
  resource = entry&.resource
  info "Registering ..."
  return if existing_demo_resources.include? resource.id   # <-- exits the whole method
  existing_demo_resources << resource.id
end
```

The first entry whose id is already known **abandons the entire bundle**, so every remaining entry goes unregistered. The registry drives later read and reference tests, so resources present on the server can silently fail to be picked up, and how many are missed depends on the order the server returns them in.

Two smaller problems in the same method:

- The `info` is emitted **before** the duplicate guard, so duplicates are announced and then discarded. In a full suite run this showed the same resource being "registered" two or three times inside a single test.
- A nil resource on an entry raises on `resource.id`.

**Change**: `each` with `next`, nil guard, and the log moved after the duplicate check so it reflects what was actually recorded. The sibling method `register_resource_id` already follows this order.

## Separate question for maintainers, not changed here

Registry and teardown bookkeeping is emitted at `info` into the same message list implementers read for conformance findings. In one 135-test run of the Smart Health Checks suite that was **301 of 1057 messages, 28% of the report**, none of it about conformance.

Moving it to a debug channel would make reports substantially easier to read, but it is a visible behaviour change for anyone relying on those messages today, so it seemed better to raise than to bundle in.