### PR TITLE
Declare the suite id before the validator in the suite template

### DIFF
--- a/lib/inferno_suite_generator/templates/suite.rb.erb
+++ b/lib/inferno_suite_generator/templates/suite.rb.erb
@@ -23,6 +23,14 @@ module <%= suite_module_name %>
       )
       version VERSION
 
+      # `id` MUST be declared before `fhir_resource_validator`. The validator captures the
+      # suite id eagerly as its `test_suite_id`, and Inferno keys validator sessions on it.
+      # If `id` comes after, the capture falls back to the base-class name
+      # "Inferno::Entities::TestSuite", which every affected suite then shares as a single
+      # validator session, collapsing separate IG versions onto one validator engine and
+      # causing intermittent "Unable to resolve profile ...|<version>" errors.
+      id :<%= suite_id %>
+
       VERSION_SPECIFIC_MESSAGE_FILTERS = <%=version_specific_message_filters%>.freeze
 
       def self.metadata
@@ -55,8 +63,6 @@ module <%= suite_module_name %>
       end
 
       links <%= links %>
-
-      id :<%= suite_id %>
 
       input :url,
         title: 'FHIR Endpoint',


### PR DESCRIPTION
Third and last piece of the AU Core validator-session collision. The first two treated the symptom in the places it showed up; this one removes the source.

## The defect

`templates/suite.rb.erb` emitted `fhir_resource_validator` before `id :<%= suite_id %>`.

Inferno captures a validator's `test_suite_id` eagerly from the declaring runnable's `id`, and keys validator sessions on `(test_suite_id, validator_name, suite_options)`. With `id` declared afterwards the capture falls back to the base-class name `Inferno::Entities::TestSuite`, so every suite generated from this template shares a single validator session. Separate IG versions then collapse onto one validator engine, whichever version built it wins, and the other fails profile resolution with:

```
Unable to resolve profile http://hl7.org.au/fhir/core/StructureDefinition/au-core-*|<version>
```

intermittently, depending on run order.

## Why it belongs here

hl7au/au-fhir-core-inferno#290 applies the same reordering directly to `lib/au_core_test_kit/generated/v1.0.0/au_core_test_suite.rb` and its v2.0.0 counterpart. Both live under `generated/`, and `suite_generator.rb` writes exactly those names:

```ruby
def base_output_file_name
  "#{ig_metadata.ig_test_id_prefix}_test_suite.rb"
end
```

So the next regeneration overwrites the fix and reinstates the collision, with nothing to indicate it happened. That makes the template the durable fix rather than the tidier one, and it is the follow-up hl7au/au-fhir-inferno#124 named when it landed the runtime workaround:

> **au_core_test_kit** (`hl7au/au-fhir-core-inferno`): move `id :au_core_vXXX` above the `fhir_resource_validator` block in the generated suites + fix the InfernoSuiteGenerator template. Then this patch can be removed.

With this merged and the kits regenerated, the boot patch in hl7au/au-fhir-inferno#124 (`lib/inferno_platform_template/patches.rb`, which rewrites any validator still keyed by the base-class name after `Inferno::Application.finalize!`) has nothing left to repair and can be retired.

## Change

`id` moves above the validator block, in the same position hl7au/au-fhir-core-inferno#290 chose, so regenerating produces the arrangement already reviewed there. The comment travels with it so the order is not quietly reversed later.

## Verification

Rendered the template standalone with stubbed bindings:

- suite `id` at line 29, `fhir_resource_validator` at line 39, so the order holds in the output rather than only in the source
- `ruby -c` passes on the rendered suite
- the inner `group do ... id :<%= fhir_api_group_id %>` is a group id and is unaffected

## Sequencing

Either order works. Merging hl7au/au-fhir-core-inferno#290 first fixes the live failures now and this makes the fix survive; merging this first and regenerating supersedes it. What does not work is #290 on its own.
