### PR TITLE
Stop appending the generated IG's version to foreign reference targets

### DIFF
--- a/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
+++ b/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
@@ -176,12 +176,14 @@ module InfernoSuiteGenerator
       true
     end
 
-    def get_target_profile_with_version(target_profile, rewrite_profile_url)
-      if rewrite_profile_url.key?(target_profile)
-        rewrite_profile_url[target_profile]
-      else
-        "#{target_profile}|#{metadata.profile_version}"
-      end
+    def resolve_target_profile_canonical(target_profile, rewrite_profile_url)
+      return rewrite_profile_url[target_profile] if rewrite_profile_url.key?(target_profile)
+
+      # Reference targets are usually profiles from a dependency rather than
+      # from the IG being generated, so the IG's own version does not apply to
+      # them. Leave the canonical unversioned and let the validator resolve
+      # whichever version the loaded packages supply.
+      target_profile
     end
 
     def resource_is_valid_with_target_profile?(resource, target_profile, rewrite_profile_url)
@@ -189,11 +191,11 @@ module InfernoSuiteGenerator
 
       validator = find_validator(:default)
 
-      target_profile_with_version = get_target_profile_with_version(target_profile, rewrite_profile_url)
+      target_profile_canonical = resolve_target_profile_canonical(target_profile, rewrite_profile_url)
       begin
         # add_messages_to_runnable is false because we only need to know if the resource is valid;
         # logging every failed reference target as an error would be noisy.
-        validator.resource_is_valid?(resource, target_profile_with_version, self, add_messages_to_runnable: false)
+        validator.resource_is_valid?(resource, target_profile_canonical, self, add_messages_to_runnable: false)
       rescue StandardError => e
         error_message = "Can't validate resource #{resource.resourceType} with profile #{target_profile}. Got error #{e.message}"
 


### PR DESCRIPTION
Split out of #30, which bundled this with an unrelated reporting change.

`get_target_profile_with_version` appends `metadata.profile_version` to any target not present in `rewrite_profile_url`. Reference targets are usually profiles from a dependency, so the IG's own version does not apply to them. A suite generated for an IG at 0.4.0 asks the validator for `au-core-patient|0.4.0`, which was never published.

Measured against a live HL7 validator, validating the same Patient:

| Requested profile | Result |
| --- | --- |
| `au-core-patient` | 200, validates normally |
| `au-core-patient\|2.0.0` | 200, validates normally |
| `au-core-patient\|0.4.0` | **HTTP 500** |

`resource_is_valid_with_target_profile?` rescues that and calls `assert false`, so the test errors instead of reporting anything about the reference.

Unmapped targets are now left unversioned and the validator resolves whichever version the loaded packages supply. `rewrite_profile_url` still takes precedence, so suites that deliberately pin a version are unaffected. Suites that only populated the map to work around this fallback can drop it.

Renamed to `resolve_target_profile_canonical`, which is what it does now that unmapped targets keep their canonical unchanged.

Independent of #36; the two touch different methods and merge in either order.
