### PR TITLE
Report a non-conformant reference target as a failure, not a skip

### DIFF
--- a/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
+++ b/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
@@ -16,17 +16,64 @@ module InfernoSuiteGenerator
 
       pass if unresolved_references(resources, rewrite_profile_url, readable_resource_types).empty?
 
-      skip_with_msg "Could not resolve and validate any Must Support references for #{unresolved_references_strings.join(", ")}"
+      # Distinguish the two ways a target can fail. A reference that was read
+      # successfully but whose target does not conform to its profile is a
+      # finding about the data, not an absence of data, and reporting it as a
+      # skip hides it. Only a genuinely unreachable reference is a skip.
+      #
+      # Findings are matched back to the element they were collected for, so a
+      # non-conformant target on an element that did resolve is never reported
+      # as the reason a different element failed to resolve.
+      findings = nonconformant_findings_for_unresolved_references
+
+      assert findings.empty?, nonconformant_reference_message(findings)
+
+      skip_with_msg "Could not resolve any Must Support references for #{unresolved_references_strings.join(", ")}"
     end
 
-    def unresolved_references_strings
+    def unresolved_references_strings(references = unresolved_references)
       unresolved_reference_hash =
-        unresolved_references.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |missing, hash|
+        references.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |missing, hash|
           hash[missing[:path]] << missing[:target_profile]
         end
       unresolved_reference_hash.map do |path, profiles|
         "#{path} element: Reference#{"(#{profiles.join("|")})" unless profiles.first.empty?}"
       end
+    end
+
+    # Reported as a failure: the element did not resolve, and at least one of
+    # its targets was read but did not conform.
+    def nonconformant_findings_for_unresolved_references
+      nonconformant_reference_findings.select do |finding|
+        unresolved_references.any? { |pair| finding_matches_reference_pair?(finding, pair) }
+      end
+    end
+
+    # Reported alongside the failure: the element did not resolve and nothing
+    # was read, so there is no conformance finding to attach to it.
+    def unreachable_unresolved_references
+      unresolved_references.reject do |pair|
+        nonconformant_reference_findings.any? { |finding| finding_matches_reference_pair?(finding, pair) }
+      end
+    end
+
+    def nonconformant_reference_message(findings)
+      described = findings.map do |finding|
+        "#{finding[:path]} element: #{finding[:reference]} does not conform to #{finding[:target_profile]}"
+      end
+
+      message = "Must Support references resolved to targets that do not conform to their profile: " \
+                "#{described.join(", ")}"
+
+      unreachable = unresolved_references_strings(unreachable_unresolved_references)
+      return message if unreachable.empty?
+
+      "#{message}. Could not resolve any Must Support references for #{unreachable.join(", ")}"
+    end
+
+    def finding_matches_reference_pair?(finding, pair)
+      finding[:target_profile] == pair[:target_profile] &&
+        (finding[:path].nil? || finding[:path] == pair[:path])
     end
 
     def record_resolved_reference(reference, target_profile)
@@ -60,6 +107,20 @@ module InfernoSuiteGenerator
       scratch[:resolved_references] ||= Set.new
     end
 
+    # References that were read successfully but whose target failed validation
+    # against its declared profile. Kept per test rather than in scratch, since
+    # it describes this test's findings rather than session-wide state. Each
+    # entry records the Must Support element it was collected for so findings
+    # can be matched back to the element that failed to resolve.
+    def nonconformant_reference_findings
+      @nonconformant_reference_findings ||= []
+    end
+
+    def record_nonconformant_reference_target(path, reference, target_profile)
+      finding = { path:, reference: reference.reference, target_profile: }
+      nonconformant_reference_findings << finding unless nonconformant_reference_findings.include?(finding)
+    end
+
     def no_resources_skip_message
       "No #{resource_type} resources appear to be available. " \
         "Please use patients with more information."
@@ -83,65 +144,81 @@ module InfernoSuiteGenerator
       end.flatten
     end
 
+    # Memoised in full, including the choice filtering below. The filter's
+    # predicate reads the collection it is mutating, so running it again on an
+    # already filtered collection can remove further entries. Callers read this
+    # more than once per test, so it has to settle on the first call.
     def unresolved_references(resources = [], rewrite_profile_url = {}, readable_resource_types = [])
-      @unresolved_references ||=
-        must_support_references_with_target_profile.select do |reference_path_profile_pair|
-          path = reference_path_profile_pair[:path]
-          target_profile = reference_path_profile_pair[:target_profile]
+      @unresolved_references ||= begin
+        unresolved =
+          must_support_references_with_target_profile.select do |reference_path_profile_pair|
+            path = reference_path_profile_pair[:path]
+            target_profile = reference_path_profile_pair[:target_profile]
 
-          found_one_reference = false
+            found_one_reference = false
 
-          resolve_one_reference = resources.any? do |resource|
-            value_found = resolve_path(resource, path, metadata:)
-            next if value_found.empty?
+            resolve_one_reference = resources.any? do |resource|
+              value_found = resolve_path(resource, path, metadata:)
+              next if value_found.empty?
 
-            resolvable = if readable_resource_types.present?
-                           value_found.select { |ref| readable_resource_types.include?(ref.resource_type) }
-                         else
-                           value_found
-                         end
+              resolvable = if readable_resource_types.present?
+                             value_found.select { |ref| readable_resource_types.include?(ref.resource_type) }
+                           else
+                             value_found
+                           end
 
-            next if resolvable.empty?
+              next if resolvable.empty?
 
-            found_one_reference = true
+              found_one_reference = true
 
-            resolvable.any? do |reference|
-              validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url)
-            end
-          end
-
-          found_one_reference && !resolve_one_reference
-        end
-
-      if metadata.must_supports[:choices].present?
-        @unresolved_references.delete_if do |reference|
-          choice_profiles = metadata.must_supports[:choices].find do |choice|
-            choice[:target_profiles]&.include?(reference[:target_profile])
-          end
-
-          choice_profiles.present? &&
-            choice_profiles[:target_profiles]&.any? do |profile|
-              @unresolved_references.none? do |element|
-                element[:target_profile] == profile
+              resolvable.any? do |reference|
+                validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url, path:)
               end
             end
-        end
-      end
 
-      @unresolved_references
+            found_one_reference && !resolve_one_reference
+          end
+
+        if metadata.must_supports[:choices].present?
+          unresolved.delete_if do |reference|
+            choice_profiles = metadata.must_supports[:choices].find do |choice|
+              choice[:target_profiles]&.include?(reference[:target_profile])
+            end
+
+            choice_profiles.present? &&
+              choice_profiles[:target_profiles]&.any? do |profile|
+                unresolved.none? do |element|
+                  element[:target_profile] == profile
+                end
+              end
+          end
+        end
+
+        unresolved
+      end
     end
 
-    def validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url)
+    def validate_reference_resolution(resource, reference, target_profile, rewrite_profile_url, path: nil)
       return true if is_reference_resolved?(reference, target_profile)
 
       if reference.contained?
         # if reference_id is blank it is referring to itself, so we know it exists
         return true if reference.reference_id.blank?
 
-        return resource.contained.any? do |contained_resource|
-                 contained_resource&.id == reference.reference_id &&
-                 resource_is_valid_with_target_profile?(contained_resource, target_profile, rewrite_profile_url)
-               end
+        contained = Array(resource.contained).select { |candidate| candidate&.id == reference.reference_id }
+
+        # Nothing with that id means the reference is unresolvable. Something
+        # with that id that fails validation is the same finding as a
+        # non-conformant external target, so it is recorded the same way.
+        return false if contained.empty?
+
+        conforms = contained.any? do |contained_resource|
+          resource_is_valid_with_target_profile?(contained_resource, target_profile, rewrite_profile_url)
+        end
+        return true if conforms
+
+        record_nonconformant_reference_target(path, reference, target_profile)
+        return false
       end
 
       reference_type = reference.resource_type
@@ -170,7 +247,13 @@ module InfernoSuiteGenerator
 
       return false unless resolved_resource&.resourceType == reference_type && resolved_resource&.id == reference_id
 
-      return false unless resource_is_valid_with_target_profile?(resolved_resource, target_profile, rewrite_profile_url)
+      unless resource_is_valid_with_target_profile?(resolved_resource, target_profile, rewrite_profile_url)
+        # The read succeeded, so the reference is reachable. The target simply
+        # does not conform. Remember that so the caller can report it as a
+        # finding rather than as missing data.
+        record_nonconformant_reference_target(path, reference, target_profile)
+        return false
+      end
 
       record_resolved_reference(reference, target_profile)
       true


### PR DESCRIPTION
Split out of #30.

## Summary

`perform_reference_resolution_test` treats two different outcomes identically: a reference that **could not be read**, and a reference that **was read fine but whose target does not conform**. Both produce the same message and a skip. The second is a finding about the data, and a skip presents it as an absence of data.

## Example

`Encounter/health-check-pat-sf` has `subject: {reference: "Patient/pat-sf"}`. The test reads it successfully (HTTP 200). `Patient/pat-sf` then fails `au-core-patient` with 29 errors, because it carries `http://www.acme.com/identifiers/patient`.

Before:

```
SKIP  Could not resolve and validate any Must Support references for
      subject element: Reference(http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient)
```

After:

```
FAIL  Must Support references resolved to targets that do not conform to their profile:
      Encounter.subject element: Patient/pat-sf does not conform to
      http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient
```

The reference is fine. The referenced Patient is not. The old output says the opposite.

### Live sessions

Public Inferno instance, current behaviour on `main`. Each link opens the test directly:

| | |
| --- | --- |
| Encounter skip | https://inferno-next.smartforms.io/smart_health_checks_v040/kt9QS5xPH5C#1.16.04 |
| MedicationStatement skip | https://inferno-next.smartforms.io/smart_health_checks_v040/kt9QS5xPH5C#1.5.06 |
| The Patient both references resolve to, failing its profile | https://inferno-next.smartforms.io/smart_health_checks_v040/kt9QS5xPH5C#1.1.02 |

The two reference tests report "Could not resolve and validate", while `#1.1.02` in the same run shows the referenced Patient failing `au-core-patient` with 29 errors. The request log on each skipped test shows `GET Patient/pat-sf` returning **200**, so the reference was read successfully.

Reproducible across three separate runs of the same suite: `kt9QS5xPH5C`, `j83RMgYnx7M`, `bsqA7Ic7hNg`, all showing the same three skips.

Why only some groups skip: `resources.any?` stops at the first reference that resolves *and* validates. Observation groups also contain resources referencing a second, conformant Patient, so they find one and pass. Encounter and MedicationStatement have no such resources, so every candidate is the non-conformant Patient.

A genuinely unreachable reference still skips, with the message narrowed to "Could not resolve".

## Why the attribution matters

Findings are collected across every Must Support element. Gating the report on "any finding collected" lets an element that resolved supply the failure message for a different element that could not be read, naming a target that was not the reason the test failed. Findings now record the element they belong to and are matched back to it. An element that was unresolved with nothing read is reported alongside the failure rather than displaced by it.

## Also in the same path

- Non-conformant **contained** targets are recorded; previously they returned a bare `false` and still surfaced as a skip.
- `unresolved_references` is memoised in full. The choice filter's predicate reads the collection it is mutating, so a second call can remove further entries, and the reporting here reads it more than once.

## Note on scope

This changes some skips into failures, which is the point, but it means suites currently passing with skipped reference tests may start failing where a referenced resource is non-conformant. In one 135-test run that was 2 tests, both genuine.

Independent of #35.

