### PR TITLE
Backport the inferno_core 1.4.x reference-resolution fix onto 9b0d17e

### DIFF
--- a/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
+++ b/lib/inferno_suite_generator/test_modules/reference_resolution_test.rb
@@ -187,22 +187,13 @@ module InfernoSuiteGenerator
     def resource_is_valid_with_target_profile?(resource, target_profile, rewrite_profile_url)
       return true if target_profile.blank?
 
-      # Only need to know if the resource is valid.
-      # Calling resource_is_valid? causes validation errors to be logged.
       validator = find_validator(:default)
 
       target_profile_with_version = get_target_profile_with_version(target_profile, rewrite_profile_url)
       begin
-        validator_response = validator.validate(resource, target_profile_with_version)
-        outcome = validator.operation_outcome_from_hl7_wrapped_response(validator_response)
-
-        message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
-
-        message_hashes.concat(validator.additional_validation_messages(resource, target_profile_with_version))
-
-        validator.filter_messages(message_hashes)
-
-        message_hashes.none? { |message_hash| message_hash[:type] == "error" }
+        # add_messages_to_runnable is false because we only need to know if the resource is valid;
+        # logging every failed reference target as an error would be noisy.
+        validator.resource_is_valid?(resource, target_profile_with_version, self, add_messages_to_runnable: false)
       rescue StandardError => e
         error_message = "Can't validate resource #{resource.resourceType} with profile #{target_profile}. Got error #{e.message}"
 


### PR DESCRIPTION
## What

Cherry-picks d468493 (`Fix reference_resolution_test to keep compatibility with inferno core 1.4.1`) onto 9b0d17e, and nothing else.

## Why

`hl7au/au-fhir-inferno` pins this gem at 9b0d17e, because that is the ref `au_core_test_kit` 1.4.4 was generated and released against. The generated AU Core v2.0.0 and v2.1.0-draft suites include `InfernoSuiteGenerator::ReferenceResolutionTest` in 44 tests between them, and at 9b0d17e that module still validates reference targets by hand out of `Validator` internals:

```ruby
validator_response = validator.validate(resource, target_profile_with_version)
outcome = validator.operation_outcome_from_hl7_wrapped_response(validator_response)
message_hashes = outcome.issue&.map { |issue| validator.message_hash_from_issue(issue, resource) } || []
message_hashes.concat(validator.additional_validation_messages(resource, target_profile_with_version))
validator.filter_messages(message_hashes)
```

inferno_core removed `operation_outcome_from_hl7_wrapped_response`, `message_hash_from_issue` and `filter_messages` in v1.1.0 (inferno-framework/inferno-core#753). The block is wrapped in `rescue StandardError` here, so on inferno_core >= 1.1.0 those 44 tests do not crash, they all fail with `Can't validate resource ... Got error undefined method`. Comparing the whole of 1.0.8 against 1.4.2, `lib/inferno/dsl/fhir_resource_validation.rb` is the only file in inferno_core that loses any method, so this one call site is the entire runtime blocker.

`main` already carries the fix. What `main` does not offer is a way to take *only* the fix: between 9b0d17e and `main` there are also changes to reference-target profile versioning, SNOMED CT edition selection, PATCH test `versionId` checking and bundle entry registration. Adopting those at the same time as an inferno_core major-minor jump would make any before/after result diff unattributable.

## Scope

One file, three insertions, twelve deletions. `resource_is_valid?(..., add_messages_to_runnable: false)` is the supported way to validate without logging, and it exists in 1.0.6 as well, so the branch runs unchanged on the currently pinned inferno_core 1.0.8 and on 1.4.2.

Merging this is optional. If it is not merged, the ref stays a branch that `au-fhir-inferno` pins, which works but leaves the platform pinned to a non-`main` ref. Merging gives a commit on `main` to pin instead.

Refs hl7au/au-fhir-inferno#162