### PR TITLE
Resolve chained search candidates from the chain target's scratch

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -70,3 +70,4 @@ exclude_paths:
   - 'test/create_test_apply_overrides_test.rb'
   - 'test/update_test_perform_update_new_test.rb'
   - 'test/ig_metadata_extractor_add_metadata_from_resources_test.rb'
+  - 'test/chained_search_test_target_test.rb'

--- a/lib/inferno_suite_generator/test_modules/chained_search_test.rb
+++ b/lib/inferno_suite_generator/test_modules/chained_search_test.rb
@@ -43,11 +43,32 @@ module InfernoSuiteGenerator
       end.flatten
     end
 
+    # Scratch keys that may hold the resources a chained search draws its identifiers from.
+    #
+    # Chained parameters are written as "<param>:<TargetType>.<element>", so the type being chained
+    # to is whatever the search parameter names, and resource scratch is keyed by type. Two naming
+    # conventions are in play and they only agree for single-word types: a generated test declares
+    # its own scratch in snake_case (:practitioner_role_resources), while find_include_resources
+    # keys included resources by downcase (:practitionerrole_resources). Both are checked rather
+    # than guessing, since a chain target can be populated by either path.
+    #
+    # This used to be hardcoded to :patient_resources, which is right for a chain onto Patient and
+    # empty for every other target, producing a test that could never find a candidate.
+    def chain_target_scratch_keys(chain_target)
+      [:"#{chain_target.underscore}_resources", :"#{chain_target.downcase}_resources"].uniq
+    end
+
+    def chain_target_resources(chain_target)
+      chain_target_scratch_keys(chain_target).filter_map { |key| scratch[key] }.first
+    end
+
     def run_chain_search_test
+      chain_target = extract_target_resource_from_chained_search_parameter(search_param_names[0])
+
       run_chain_search_test_clean(
         search_param_names[0],
         patient_id_list,
-        scratch[:patient_resources],
+        chain_target_resources(chain_target),
         attr_paths,
         target_identifier
       )
@@ -76,12 +97,22 @@ module InfernoSuiteGenerator
                                     target_identifier)
       passed = false
 
+      chain_target = extract_target_resource_from_chained_search_parameter(search_param)
+
       identifiers_to_test = all_chain_identifier_values(
         patient_id_list,
         all_patients_resources,
-        extract_target_resource_from_chained_search_parameter(search_param),
+        chain_target,
         target_identifier
       )
+
+      # Without a candidate identifier there is nothing to search on, so no request is made. The
+      # assertion below describes a response, so reporting it here would blame the server for a
+      # result it was never asked to produce. Omit instead, and say which scratch was empty.
+      if identifiers_to_test.compact.empty?
+        omit "No #{chain_target} resource with a usable identifier was available to build the " \
+             "#{search_param} search. Nothing was requested from the server."
+      end
 
       identifiers_to_test.each do |identifier_to_test|
         next if identifier_to_test.nil?

--- a/test/chained_search_test_target_test.rb
+++ b/test/chained_search_test_target_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "active_support/all"
+require "inferno_suite_generator/test_modules/chained_search_test"
+
+module InfernoSuiteGenerator
+  # Covers how a chained search decides which resources to draw its candidate identifiers from,
+  # and what it reports when there are none.
+  #
+  # A chained parameter names the type it chains to ("practitioner:Practitioner.identifier"), and
+  # the candidates have to come from that type's scratch. Drawing them from Patient scratch
+  # regardless meant any chain onto a non-Patient target found nothing, issued no request, and
+  # still failed with a message about the response.
+  class ChainedSearchTestTargetTest < Minitest::Test
+    # Minimal include host. Only the collaborators the methods under test touch are provided;
+    # `omit` is captured rather than raised so the message can be asserted on.
+    class ChainHost
+      include ChainedSearchTest
+
+      attr_accessor :scratch
+      attr_reader :omitted_with, :searches
+
+      def initialize(scratch)
+        @scratch = scratch
+        @searches = []
+        @omitted_with = nil
+      end
+
+      def omit(message)
+        @omitted_with = message
+        throw :omitted
+      end
+
+      def search_and_check_response(params)
+        @searches << params
+      end
+
+      def fetch_all_bundled_resources = []
+    end
+
+    # Stand-ins for the FHIR models: the code under test only reads resourceType and the
+    # identifier's system and value.
+    Identifier = Struct.new(:system, :value)
+    Resource = Struct.new(:resourceType, :identifier)
+
+    IDENTIFIER = Identifier.new("http://ns.electronichealth.net.au/id/hi/hpii/1.0", "8003611566719005").freeze
+
+    def practitioner = Resource.new("Practitioner", [IDENTIFIER])
+
+    def patient = Resource.new("Patient", [IDENTIFIER])
+
+    def test_chain_target_drives_the_scratch_key
+      host = ChainHost.new({})
+
+      assert_equal %i[patient_resources], host.chain_target_scratch_keys("Patient")
+      assert_equal %i[practitioner_resources], host.chain_target_scratch_keys("Practitioner")
+    end
+
+    # Included resources are keyed by downcase and a test's own scratch by snake_case, so both
+    # spellings are accepted for a multi-word target rather than one being guessed.
+    def test_multi_word_target_accepts_both_scratch_conventions
+      host = ChainHost.new({})
+
+      assert_equal %i[practitioner_role_resources practitionerrole_resources],
+                   host.chain_target_scratch_keys("PractitionerRole")
+    end
+
+    def test_resources_are_read_from_the_target_scratch_not_patient_scratch
+      host = ChainHost.new(
+        patient_resources: { "pat-1" => [patient] },
+        practitioner_resources: { "pat-1" => [practitioner] }
+      )
+
+      found = host.chain_target_resources("Practitioner")
+
+      assert_equal ["pat-1"], found.keys
+      assert_equal "Practitioner", found["pat-1"].first.resourceType
+    end
+
+    def test_chain_onto_a_non_patient_target_finds_its_candidates
+      host = ChainHost.new(practitioner_resources: { "pat-1" => [practitioner] })
+
+      candidates = host.all_chain_identifier_values(
+        ["pat-1"], host.chain_target_resources("Practitioner"), "Practitioner", nil
+      )
+
+      refute_empty candidates, "a Practitioner chain should find the Practitioner in its own scratch"
+      assert_equal "8003611566719005", candidates.first[:identifier].value
+    end
+
+    # The regression: Practitioner candidates are not in Patient scratch, so the old lookup
+    # produced an empty list for every server and every run.
+    def test_patient_scratch_holds_no_candidates_for_a_practitioner_chain
+      host = ChainHost.new(patient_resources: { "pat-1" => [patient] })
+
+      candidates = host.all_chain_identifier_values(
+        ["pat-1"], host.scratch[:patient_resources], "Practitioner", nil
+      )
+
+      assert_empty candidates
+    end
+
+    def test_no_candidates_omits_without_issuing_a_request
+      host = ChainHost.new({})
+
+      catch(:omitted) do
+        host.run_chain_search_test_clean(
+          "practitioner:Practitioner.identifier", ["pat-1"], nil, ["practitioner"], nil
+        )
+        flunk "expected the test to omit when no candidate identifier could be built"
+      end
+
+      assert_empty host.searches, "no request should be made when there is nothing to search on"
+      assert_match(/No Practitioner resource/, host.omitted_with)
+      assert_match(/Nothing was requested from the server/, host.omitted_with)
+    end
+  end
+end


### PR DESCRIPTION
Example fix for #40. Two changes, both in `chained_search_test.rb`, and they are independent if you only want one.

**Derive the scratch key from the chain target.** `run_chain_search_test` hardcoded `scratch[:patient_resources]`, which is right for a chain onto Patient and empty for anything else, so `practitioner:Practitioner.identifier` could never find a candidate. Patient still resolves to `:patient_resources`, so the 84 Patient-target chain tests in an AU Core suite behave exactly as before and only the one Practitioner-target test changes.

**Omit instead of failing when no candidate could be built.** The assertion at the end of `run_chain_search_test_clean` describes a response, but an empty candidate list means the loop never ran and nothing was requested. That covers the second route into this too: run a group without the Patient group ahead of it and patient scratch is empty, which currently fails every chain test in that group.

```
No Practitioner resource with a usable identifier was available to build the
practitioner:Practitioner.identifier search. Nothing was requested from the server.
```

## What this does not fix

The chain test is still generated before the `_include` tests that populate the chain target's scratch:

```
98:  test from: ..._practitioner_chain_search_test
102: test from: ..._practitioner_include_practitioner_search_test
```

So a Practitioner chain now omits accurately rather than failing misleadingly, but it still does not exercise the search. Making it run means generating chain tests after include tests in `lib/inferno_suite_generator.rb`, which reorders every generated group, so it seemed like your call rather than something to bundle in here. Happy to do it as a follow-up.

## On the scratch key spelling

Keys are built two ways in the current code: `.downcase` in `find_include_resources`, snake_case in a generated test's own `scratch_resources`. Those agree for every single-word type and diverge for `PractitionerRole` and `RelatedPerson`. Rather than guess which one a future chain target lands under, `chain_target_scratch_keys` accepts both. Normalising them properly would be better and I did not want to do it silently inside this change.

## Testing

Six unit tests in `test/chained_search_test_target_test.rb`, covering key derivation, both spellings for a multi-word target, reading from the target's scratch rather than Patient's, and the omit path asserting that no request is issued. One is a characterisation test showing that Patient scratch holds no Practitioner candidates, which is the bug in one assertion.

`rake test` 114 runs, 0 failures. `rubocop` clean, 44 files. On `main` the same six tests error out, five of them because the methods do not exist and the sixth because it reaches the `assert` instead of omitting.

Nothing here changes generated output, so no regeneration is needed to pick it up.
