### PR TITLE
Generate chained search tests after the _include tests

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -71,3 +71,4 @@ exclude_paths:
   - 'test/update_test_perform_update_new_test.rb'
   - 'test/ig_metadata_extractor_add_metadata_from_resources_test.rb'
   - 'test/chained_search_test_target_test.rb'
+  - 'test/generation_order_test.rb'

--- a/lib/inferno_suite_generator.rb
+++ b/lib/inferno_suite_generator.rb
@@ -48,6 +48,11 @@ module InfernoSuiteGenerator
       generate_read_tests
       generate_provenance_revinclude_search_tests
       generate_include_search_tests
+      # After the _include tests, which are what populate the scratch a chained search draws its
+      # candidate identifiers from. A chain onto a type that is not the patient compartment (for
+      # example practitioner:Practitioner.identifier on PractitionerRole) has nothing to search on
+      # until those have run, because a group's tests execute in the order they are generated.
+      generate_chain_search_tests
       generate_validation_tests
       generate_must_support_tests
       generate_reference_resolution_tests
@@ -104,7 +109,6 @@ module InfernoSuiteGenerator
       SearchTestGenerator.generate(ig_metadata, base_output_dir)
       generate_multiple_or_search_tests
       generate_multiple_and_search_tests
-      generate_chain_search_tests
       generate_custom_tests_with_type("search")
     end
 

--- a/test/generation_order_test.rb
+++ b/test/generation_order_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "inferno_suite_generator"
+
+module InfernoSuiteGenerator
+  # Pins the order in which test files are generated, because that order becomes the order the
+  # tests run in inside a group: GroupMetadata#add_test appends as each generator runs, and
+  # GroupGenerator emits "test from:" straight from that list.
+  #
+  # Chained search tests have to be generated after the _include tests. A chained parameter draws
+  # its candidate identifiers from the scratch of the type it chains to, and for a target outside
+  # the patient compartment (practitioner:Practitioner.identifier on PractitionerRole) the only
+  # thing that populates that scratch is the _include test for the same reference.
+  class GenerationOrderTest < Minitest::Test
+    # Records which generation steps run, in order, without touching the IG package or disk.
+    class OrderRecordingGenerator < Generator
+      attr_reader :steps
+
+      def initialize
+        super("unused")
+        @steps = []
+      end
+
+      %i[
+        load_ig_package extract_metadata extract_demodata
+        generate_search_tests generate_read_tests generate_provenance_revinclude_search_tests
+        generate_include_search_tests generate_chain_search_tests generate_validation_tests
+        generate_must_support_tests generate_reference_resolution_tests generate_create_tests
+        generate_update_tests generate_patch_tests generate_groups generate_suites use_tests
+      ].each do |step|
+        define_method(step) do
+          @steps << step
+          nil
+        end
+      end
+    end
+
+    def setup
+      @generator = OrderRecordingGenerator.new
+      @generator.generate
+    end
+
+    # Fails rather than blowing up on a nil comparison when a step is not reached at all, which is
+    # what happens when chain generation is nested inside another step instead of being its own.
+    def index_of(step)
+      index = @generator.steps.index(step)
+      refute_nil index, "#{step} was never reached during generate"
+      index
+    end
+
+    def test_chain_search_tests_are_generated_after_include_search_tests
+      assert index_of(:generate_chain_search_tests) > index_of(:generate_include_search_tests),
+             "chained search tests must be generated after the _include tests that populate the " \
+             "scratch they read their candidate identifiers from"
+    end
+
+    # Chain tests still belong with the searches rather than trailing the whole group.
+    def test_chain_search_tests_are_generated_before_the_closing_tests
+      %i[generate_validation_tests generate_must_support_tests generate_reference_resolution_tests]
+        .each do |later_step|
+        assert index_of(:generate_chain_search_tests) < index_of(later_step),
+               "chained search tests should still precede #{later_step}"
+      end
+    end
+
+    def test_groups_are_generated_after_every_test_type
+      last_test_step = index_of(:generate_patch_tests)
+
+      assert index_of(:generate_groups) > last_test_step,
+             "groups collect the tests, so they must be generated last"
+    end
+  end
+end


### PR DESCRIPTION
Stacked on #41, which is the base branch here. Together they make `practitioner_role_practitioner_chain_search_test` actually run instead of omitting. Follow-up to #40.

A group's tests run in the order they are generated. `GroupMetadata#add_test` appends as each generator runs, and `GroupGenerator` emits `test from:` straight from that list, so generation order is run order. Chain tests were generated inside `generate_search_tests`, which put them ahead of the `_include` tests in every group.

That is wrong for a chain onto a type outside the patient compartment. The candidates come from the chain target's scratch, and the only thing that populates it is the `_include` test for the same reference. In AU Core the chain test ran at position 10 and the include test that fetches the Practitioners it needs ran at position 13, so there was never anything to search on.

## Verified by regenerating

Rebuilt the AU Core v3.0.0-ballot1 suite against this branch. The chain test moves from 10 to 15, directly after the four `_include` tests:

```
 8  practitioner_multiple_or_search_test
 9  practitioner_multiple_and_search_test
10  identifier_medicare_search_test
11  _id_include__id_search_test
12  identifier_include_identifier_search_test
13  practitioner_include_practitioner_search_test
14  specialty_include_specialty_search_test
15  practitioner_chain_search_test     <- was 10
16  validation_test
17  must_support_test
```

Footprint is ordering and nothing else: 24 group files and 23 metadata files, no test content changed. (Regenerating also produces unrelated formatting churn across ~500 files unless you run `rubocop -A` afterwards as the Makefile does. With that step the diff is just the 47.)

The two halves line up: `test_include_param` writes the fetched resources to `scratch[:"#{target_resource.downcase}_resources"]`, which is `:practitioner_resources`, and `chain_target_scratch_keys("Practitioner")` from #41 resolves to the same key.

## Scope

Chain generation moves out of `generate_search_tests` and is called after `generate_include_search_tests`, still ahead of validation, must support and reference resolution so chains stay grouped with the other searches rather than trailing the whole group. This reorders chain tests in every generated group for every suite built with the gem, which is why I kept it out of #41.

## Testing

`test/generation_order_test.rb` pins the contract by recording the steps `generate` runs, since the coupling between generation order and run order is not obvious from either side. Without the change it fails with `generate_chain_search_tests was never reached during generate`.

`rake test` 117 runs, 0 failures. `rubocop` clean. `reek` 0 warnings.

Unlike #41 this one does need a regeneration to take effect in a downstream kit.
